### PR TITLE
Copy and paste error

### DIFF
--- a/src/de/unihd/dbs/uima/annotator/heideltime/HeidelTime.java
+++ b/src/de/unihd/dbs/uima/annotator/heideltime/HeidelTime.java
@@ -2230,7 +2230,7 @@ public class HeidelTime extends JCasAnnotator_ImplBase {
 						}
 					} else if (timexType.equals("TEMPONYM")) {
 						if (hmTemponymPosConstraint.containsKey(hmPattern.get(p))) {
-							posConstraintOK = checkPosConstraint(s , hmSetPosConstraint.get(hmPattern.get(p)), r, jcas);
+							posConstraintOK = checkPosConstraint(s , hmTemponymPosConstraint.get(hmPattern.get(p)), r, jcas);
 						}
 					}
 					


### PR DESCRIPTION
Found this when checking for optimizations.

Also, in line #L2305 is the `matches` (regular expression matching) operation intentional? If so, these should be kept as Pattern rather than String for better performance.