### PR TITLE
ListResult output

### DIFF
--- a/src/de/unihd/dbs/heideltime/standalone/HeidelTimeStandalone.java
+++ b/src/de/unihd/dbs/heideltime/standalone/HeidelTimeStandalone.java
@@ -46,6 +46,7 @@ import de.unihd.dbs.heideltime.standalone.components.impl.IntervalTaggerWrapper;
 import de.unihd.dbs.heideltime.standalone.components.impl.JCasFactoryImpl;
 import de.unihd.dbs.heideltime.standalone.components.impl.JVnTextProWrapper;
 import de.unihd.dbs.heideltime.standalone.components.impl.StanfordPOSTaggerWrapper;
+import de.unihd.dbs.heideltime.standalone.components.impl.ListResultFormatter; 
 import de.unihd.dbs.heideltime.standalone.components.impl.TimeMLResultFormatter;
 import de.unihd.dbs.heideltime.standalone.components.impl.TreeTaggerWrapper;
 import de.unihd.dbs.heideltime.standalone.components.impl.UimaContextImpl;
@@ -428,8 +429,12 @@ public class HeidelTimeStandalone {
 	private ResultFormatter getFormatter() {
 		if (outputType.toString().equals("xmi")){
 			return new XMIResultFormatter();
-		} else {
-			return new TimeMLResultFormatter();
+		} 
+		else if (outputType.toString().equals("list")) {
+			return new ListResultFormatter();
+		}
+		else{
+			return new TimeMLResultFormatter();	
 		}
 	}
 

--- a/src/de/unihd/dbs/heideltime/standalone/OutputType.java
+++ b/src/de/unihd/dbs/heideltime/standalone/OutputType.java
@@ -30,5 +30,10 @@ public enum OutputType {
 		public String toString() {
 			return "xmi";
 		}
+	},
+	LIST {
+		public String toString() {
+			return "list"; 
+		}
 	}
 }

--- a/src/de/unihd/dbs/heideltime/standalone/components/impl/ListResultFormatter.java
+++ b/src/de/unihd/dbs/heideltime/standalone/components/impl/ListResultFormatter.java
@@ -1,0 +1,63 @@
+/*
+ * ListResultFormatter.java
+ *
+ * Copyright (c) 2011, Database Research Group, Institute of Computer Science, University of Heidelberg.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the GNU General Public License.
+ *
+ */ 
+
+package de.unihd.dbs.heideltime.standalone.components.impl;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.uima.cas.FSIterator;
+import org.apache.uima.jcas.JCas;
+
+import de.unihd.dbs.heideltime.standalone.components.ResultFormatter;
+import de.unihd.dbs.uima.types.heideltime.Timex3;
+import de.unihd.dbs.uima.types.heideltime.Timex3Interval;
+
+/**
+ * List Results Formatter
+ * 
+ * 
+ * @author Francesco Paolo Albano, Politecnico di Bari
+ * @version 1.0
+ */
+public class ListResultFormatter implements ResultFormatter {
+	public String format(JCas jcas) throws Exception {
+		final String documentText = jcas.getDocumentText();
+		String outText = new String();
+
+
+		//Logger l = Logger.getLogger("ListResultFormatter");
+		//l.log(Level.INFO, "Start List ResultFormatter");
+
+		FSIterator iterIntervals = jcas.getAnnotationIndex(Timex3Interval.type).iterator();
+		while(iterIntervals.hasNext()) {
+			Timex3Interval t = (Timex3Interval) iterIntervals.next();
+
+			Integer start = t.getBegin();
+			Integer end = t.getEnd();
+			outText += t.getTimexType()+"\t"+start+" "+end+"\t"+documentText.substring(start, end)+"\t"+t.getTimexValueEB()+"-"+t.getTimexValueLB() +"\t"+t.getTimexValueEE()+"-"+t.getTimexValueLE()+"\n";
+		}
+
+
+		//only for timex3
+		//we want TYPE start end Text NormalizedValue
+		FSIterator iterTimex = jcas.getAnnotationIndex(Timex3.type).iterator();
+		while(iterTimex.hasNext()) {
+			Timex3 t = (Timex3) iterTimex.next();
+
+
+			Integer start = t.getBegin();
+			Integer end = t.getEnd();
+			outText += t.getTimexType()+"\t"+start+" "+end+"\t"+documentText.substring(start, end)+"\t"+t.getTimexValue()+"\n";
+		}
+
+		//l.log(Level.INFO, "End List ResultFormatter");
+		return outText;
+	}
+}


### PR DESCRIPTION
I have added the possibility to get the results in another format. I have added the class ListResultFormatter, and using the argument **-o list** .
Example:
![screen2](https://cloud.githubusercontent.com/assets/19225138/22517110/5d3956f8-e8a8-11e6-9655-aae564bf4a2a.png)

The second column contain the begin and the end of temporal expression, separated by a blank
The Third column is the temporal expression
The last column is the normalized value

The other output type also work