### PR TITLE
fixed the pom snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A minimal set of dependencies is satisfied by these entries for your pom.xml:
 		<dependency>
 			<groupId>com.github.heideltime</groupId>
 			<artifactId>heideltime</artifactId>
-			<version>2.2</version>
+			<version>2.2.1</version>
 		</dependency>
 ```
 


### PR DESCRIPTION
It would appear that there is no such version as 2.2 of heideltime, but there is a 2.2.1.

This probably also needs fixing on your maven wiki page, but I couldn't figure out how to edit that page as part of a pull request.